### PR TITLE
Set charset=utf-8 for /raw/{id} response

### DIFF
--- a/src/endpoints/pasta.rs
+++ b/src/endpoints/pasta.rs
@@ -305,7 +305,7 @@ pub async fn getrawpasta(
 
         // send raw content of pasta
         let response = Ok(HttpResponse::NotFound()
-            .content_type("text/plain")
+            .content_type("text/plain; charset=utf-8")
             .body(pastas[index].content.to_owned()));
 
         return response;


### PR DESCRIPTION
This matches `<meta charset="utf-8">` in HTML and thus lets browser decode content properly.